### PR TITLE
Fix code scanning alert no. 87: Database query built from user-controlled sources

### DIFF
--- a/server.js
+++ b/server.js
@@ -5962,13 +5962,13 @@ async function async_updateClanScore(_clan, _score, _kills)
         let collection = db.collection("clans");
 
         let res = await collection.findOne({
-            name: _clan
+            name: { $eq: _clan }
         });
         if (res)
         {
             let resUpdate = await collection.updateOne(
                 {
-                    name: _clan
+                    name: { $eq: _clan }
                 },
                 {
                     $inc: {


### PR DESCRIPTION
Fixes [https://github.com/WilkinGames/deadswitch3-mp-custom/security/code-scanning/87](https://github.com/WilkinGames/deadswitch3-mp-custom/security/code-scanning/87)

To fix the problem, we need to ensure that the `clan` value is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator in the query to ensure that the user input is interpreted as a literal value and not as a query object. This change should be made in the `async_updateClanScore` function where the MongoDB query is constructed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
